### PR TITLE
Add an Include Index checkbox to the Add Report modal

### DIFF
--- a/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.test.tsx
@@ -411,6 +411,21 @@ test('renders screenshot options when dashboard is selected', async () => {
       name: /ignore cache when generating report/i,
     }),
   ).toBeInTheDocument();
+
+});
+
+test('properly renders include index checkbox', async () => {
+  render(<AlertReportModal {...generateMockedProps(true, true, false)} />, {
+    useRedux: true,
+  });
+  userEvent.click(screen.getByTestId('contents-panel'));
+  await screen.findByText(/test chart/i);
+  expect(
+    screen.getByRole('checkbox', {
+      name: /include index column/i,
+    }),
+  ).toBeInTheDocument();
+
 });
 
 test('changes to content options when chart is selected', async () => {

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -426,6 +426,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     DEFAULT_NOTIFICATION_FORMAT,
   );
   const [forceScreenshot, setForceScreenshot] = useState<boolean>(false);
+  const [includeIndex, setIncludeIndex] = useState<boolean>(false);
 
   const [isScreenshot, setIsScreenshot] = useState<boolean>(false);
   useEffect(() => {
@@ -630,6 +631,7 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       ...currentAlert,
       type: isReport ? 'Report' : 'Alert',
       force_screenshot: shouldEnableForceScreenshot || forceScreenshot,
+      includeIndex: includeIndex,
       validator_type: conditionNotNull ? 'not null' : 'operator',
       validator_config_json: conditionNotNull
         ? {}
@@ -993,6 +995,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
 
   const onForceScreenshotChange = (event: any) => {
     setForceScreenshot(event.target.checked);
+  };
+
+  const onIncludeIndexChange = (event: any) => {
+    setIncludeIndex(event.target.checked);
   };
 
   // Make sure notification settings has the required info
@@ -1629,6 +1635,18 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                 onChange={onForceScreenshotChange}
               >
                 {t('Ignore cache when generating report')}
+              </StyledCheckbox>
+            </div>
+          )}
+          {(isReport) && (
+            <div className="inline-container">
+              <StyledCheckbox
+                data-test="include-index"
+                className="checkbox"
+                checked={includeIndex}
+                onChange={onIncludeIndexChange}
+              >
+                {t('Include index column')}
               </StyledCheckbox>
             </div>
           )}


### PR DESCRIPTION
### SUMMARY
This is an attempt to implement [this request](https://github.com/apache/superset/pull/29335#issuecomment-2189038871) from someone who's never touched these modals at all. There's some code missing to link things up but I think this at least implements the UI stuff. I'm hoping @SkinnyPigeon can work with me to get this all the way to done.

### TESTING INSTRUCTIONS
### ADDITIONAL INFORMATION
* [x] Has associated issue:
* [ ] Required feature flags:
* [x] Changes UI
* [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  * [ ] Migration is atomic, supports rollback & is backwards-compatible
  * [ ] Confirm DB migration upgrade and downgrade tested
  * [ ] Runtime estimates and downtime expectations provided
* [ ] Introduces new feature or API
* [ ] Removes existing feature or API